### PR TITLE
Magic Stores now have the correct spells

### DIFF
--- a/FF1 PRR/FF1 PRR/Form1.cs
+++ b/FF1 PRR/FF1 PRR/Form1.cs
@@ -233,8 +233,8 @@ namespace FF1_PRR
 			// Begin randomization
 			r1 = new Random(Convert.ToInt32(RandoSeed.Text));
 			doDatabaseEdits();
-			if (RandoShop.SelectedIndex > 0) randomizeShops();
-			if (randoMagic.Checked) randomizeMagic(keepMagicPermissions.Checked);
+			Magic magicData = randomizeMagic(randoMagic.Checked, keepMagicPermissions.Checked);
+			if (RandoShop.SelectedIndex > 0) randomizeShops(magicData);
 			if (KeyItems.Checked) randomizeKeyItems();
 			if (flagT.SelectedIndex > 0) randomizeTreasure();
 			monsterBoost();
@@ -330,17 +330,20 @@ namespace FF1_PRR
 				}
 			}
 		}
-		private void randomizeShops()
+		private void randomizeShops(Magic magicData)
 		{
 			Shops randoShops = new Shops(r1, RandoShop.SelectedIndex, 
 				Path.Combine(FF1PRFolder.Text, "FINAL FANTASY_Data", "StreamingAssets", "Assets", "GameAssets", "Serial", "Data", "Master", "product.csv"), 
-				Traditional.Checked);
+				Traditional.Checked, magicData);
 		}
 
-		private void randomizeMagic(bool keepPermissions)
+		private Magic randomizeMagic(bool randomizeMagic, bool keepPermissions)
 		{
-			new Inventory.Magic().shuffleMagic(r1, keepPermissions,
+			Magic magicData = new Inventory.Magic(
 				Path.Combine(FF1PRFolder.Text, "FINAL FANTASY_Data", "StreamingAssets", "Assets", "GameAssets", "Serial", "Data", "Master", "ability.csv"));
+			if (randomizeMagic) magicData.shuffleMagic(r1, keepPermissions);
+			magicData.writeToFile();
+			return magicData;
 		}
 
 		private void randomizeKeyItems()

--- a/FF1 PRR/FF1 PRR/Inventory/Magic.cs
+++ b/FF1 PRR/FF1 PRR/Inventory/Magic.cs
@@ -85,6 +85,37 @@ namespace FF1_PRR.Inventory
 		public List<int> bAll = Enum.GetValues(typeof(blackMagic)).Cast<int>().ToList();
 		public List<int> wAll = Enum.GetValues(typeof(whiteMagic)).Cast<int>().ToList();
 
+		public static int WHITE_MAGIC = 1;
+		public static int BLACK_MAGIC = 2;
+		public static int DUPE_CURE_4 = 100;
+
+		private List<ability> records;
+		private string file;
+
+		public Magic(string fileName)
+        {
+			file = fileName;
+			using (StreamReader reader = new StreamReader(fileName))
+			using (CsvReader csv = new CsvReader(reader, System.Globalization.CultureInfo.InvariantCulture))
+			{
+				records = csv.GetRecords<ability>().ToList();
+			}
+		}
+
+		public List<ability> getRecords()
+        {
+			return records;
+        }
+
+		public void writeToFile()
+        {
+			using (StreamWriter writer = new StreamWriter(file))
+			using (CsvWriter csv = new CsvWriter(writer, System.Globalization.CultureInfo.InvariantCulture))
+			{
+				csv.WriteRecords(records);
+			}
+		}
+
 		public List<int> shuffleShops(Random r1, int type)
 		{
 			List<int> shuffler = type == 0 ? all : type == 1 ? wAll : bAll;
@@ -93,7 +124,7 @@ namespace FF1_PRR.Inventory
 			return shuffler;
 		}
 
-		private class ability
+		public class ability
 		{
 			public int id { get; set; }
 			public int sort_id { get; set; }
@@ -135,10 +166,10 @@ namespace FF1_PRR.Inventory
 			public int data_c { get; set; }
 		}
 
-		public void shuffleMagic(Random r1, bool keepPermissions, string fileName)
+		public void shuffleMagic(Random r1, bool keepPermissions)
 		{
 			all.AddRange(Enum.GetValues(typeof(blackMagic)).Cast<int>().ToList());
-			List<ability> records;
+			
 
 			// Shuffle levels and price between the white spells and then the black spells.
 			List<int> wMagic = new List<int> {
@@ -161,12 +192,6 @@ namespace FF1_PRR.Inventory
 				56, 57, 58, 59,
 				64, 65, 66, 67
 			};
-
-			using (StreamReader reader = new StreamReader(fileName))
-			using (CsvReader csv = new CsvReader(reader, System.Globalization.CultureInfo.InvariantCulture))
-			{
-				records = csv.GetRecords<ability>().ToList();
-			}
 
 			// TODO:  id + (r1.Next() % 100), sort from there.
 			for (int lnI = 0; lnI < 1280; lnI++)
@@ -228,12 +253,6 @@ namespace FF1_PRR.Inventory
 						}
 					}
 				}
-			}
-
-			using (StreamWriter writer = new StreamWriter(fileName))
-			using (CsvWriter csv = new CsvWriter(writer, System.Globalization.CultureInfo.InvariantCulture))
-			{
-				csv.WriteRecords(records);
 			}
 		}
 	}

--- a/FF1 PRR/FF1 PRR/Randomize/Shops.cs
+++ b/FF1 PRR/FF1 PRR/Randomize/Shops.cs
@@ -104,7 +104,60 @@ namespace FF1_PRR.Randomize
 			return shopDB;
 		}
 
-		public Shops(Random r1, int randoLevel, string fileName, bool traditional)
+		private int determineMagicShop(int[,] magicMemory, int type, int level)
+        {
+			int[,,] spellShopLookup = {
+										{
+											{ whiteMagicStores[0], whiteMagicStores[0], whiteMagicStores[0], whiteMagicStores[0]},
+											{ whiteMagicStores[1], whiteMagicStores[1], whiteMagicStores[1], whiteMagicStores[1]},
+											{ whiteMagicStores[2], whiteMagicStores[2], whiteMagicStores[2], whiteMagicStores[2]},
+											{ whiteMagicStores[3], whiteMagicStores[3], whiteMagicStores[3], whiteMagicStores[3]},
+											{ whiteMagicStores[4], whiteMagicStores[4], whiteMagicStores[4], whiteMagicStores[4]},
+											{ whiteMagicStores[5], whiteMagicStores[5], whiteMagicStores[5], whiteMagicStores[5]},
+											{ whiteMagicStores[6], whiteMagicStores[6], whiteMagicStores[8], whiteMagicStores[8]},
+											{ whiteMagicStores[7], whiteMagicStores[7], whiteMagicStores[9], whiteMagicStores[9]}
+										},
+										{
+											{ blackMagicStores[0], blackMagicStores[0], blackMagicStores[0], blackMagicStores[0]},
+											{ blackMagicStores[1], blackMagicStores[1], blackMagicStores[1], blackMagicStores[1]},
+											{ blackMagicStores[2], blackMagicStores[2], blackMagicStores[2], blackMagicStores[2]},
+											{ blackMagicStores[3], blackMagicStores[3], blackMagicStores[3], blackMagicStores[3]},
+											{ blackMagicStores[4], blackMagicStores[4], blackMagicStores[4], blackMagicStores[4]},
+											{ blackMagicStores[5], blackMagicStores[5], blackMagicStores[5], blackMagicStores[5]},
+											{ blackMagicStores[6], blackMagicStores[6], blackMagicStores[8], blackMagicStores[8]},
+											{ blackMagicStores[7], blackMagicStores[7], blackMagicStores[9], blackMagicStores[9]}
+										}
+									};
+			return spellShopLookup[type - 1, level - 1, magicMemory[type - 1, level - 1]];
+		}
+
+		private List<shopItem> determineSpells(Magic magicData)
+        {
+			List<shopItem> shopDB = new List<shopItem>();
+			int[,] magicMemory = new int[2, 8];
+
+			foreach (Magic.ability spell in magicData.getRecords())
+            {
+				if (spell.ability_group_id == 1 && spell.id != Magic.DUPE_CURE_4) //if it's a spell and not chaos's special Cure4
+                {
+					shopItem newItem = new shopItem();
+					newItem.id = 0;
+					newItem.content_id = spell.id + 208; //Magic Constant for Ability ID -> shop ID map
+					if (spell.ability_lv <= 6)
+                    {
+						newItem.group_id = blackMagicStores[spell.ability_lv - 1];
+
+					}
+					newItem.group_id = determineMagicShop(magicMemory, spell.type_id, spell.ability_lv);
+					magicMemory[spell.type_id - 1, spell.ability_lv - 1]++;
+					shopDB.Add(newItem);
+				}
+            }
+
+			return shopDB;
+		}
+
+		public Shops(Random r1, int randoLevel, string fileName, bool traditional, Magic magicData)
 		{
 			List<shopItem> shopDB = new List<shopItem>();
 
@@ -155,8 +208,7 @@ namespace FF1_PRR.Randomize
 
 				// TODO:  Remove duplicates within each store.
 			}
-			shopDB.AddRange(determineItems(new Magic().shuffleShops(r1, 1), whiteMagicStores, r1));
-			shopDB.AddRange(determineItems(new Magic().shuffleShops(r1, 2), blackMagicStores, r1));
+			shopDB.AddRange(determineSpells(magicData));
 
 			using (StreamWriter sw = new StreamWriter(fileName))
 			{


### PR DESCRIPTION
This updates how magic stores handle their spells:

* All stores have inventories based on the level of their vanilla stock (ie Corneria White Magic will be all L1 White spells; Crescent Lake Black Magic will be all L6 Black Magic)
* Reworked Magic.cs to be state-y in order to support this.